### PR TITLE
Fixes the dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "browser-cookie-lite": "0.3.1",
     "jstimezonedetect": "1.0.5",
     "murmurhash": "0.0.2",
-    "sha1": "git://github.com/pvorb/node-sha1.git#910081c83f3661507d9d89e66e3f38d8b59d5559",
+    "sha1": "https://github.com/pvorb/node-sha1.git#910081c83f3661507d9d89e66e3f38d8b59d5559",
     "uuid": "2.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
`git://` urls aren't supported anymore for GitHub